### PR TITLE
Create different changetype for whitespace diffs

### DIFF
--- a/src/Mpmd/Util/Compare.php
+++ b/src/Mpmd/Util/Compare.php
@@ -32,10 +32,11 @@ class Compare
     public function compareDirectories($baseDirA, $baseDirB, $path='', $ignore=array())
     {
         $data = array(
-            self::DIFFERENT_FILE_CONTENT => array(),
-            self::IDENTICAL_FILES        => array(),
-            self::FILE_MISSING_IN_B      => array(),
-            self::SAME_FILE_BUT_COMMENTS => array(),
+            self::DIFFERENT_FILE_CONTENT   => array(),
+            self::IDENTICAL_FILES          => array(),
+            self::FILE_MISSING_IN_B        => array(),
+            self::SAME_FILE_BUT_COMMENTS   => array(),
+            self::SAME_FILE_BUT_WHITESPACE => array(),
         );
         if ($handle = opendir($baseDirA . $path)) {
             while ($file = readdir($handle)) {
@@ -83,9 +84,7 @@ class Compare
         $extension = strtolower(pathinfo($aFile, PATHINFO_EXTENSION));
         
         $additionalCheck = in_array($extension, array('php', 'phtml', 'xml'));
-        if ($additionalCheck
-            && ($this->getFileContentWithoutWhitespace($aFile) === $this->getFileContentWithoutWhitespace($bFile))
-        ) {
+        if ($this->getFileContentWithoutWhitespace($aFile) === $this->getFileContentWithoutWhitespace($bFile)) {
             return self::SAME_FILE_BUT_WHITESPACE;
         } elseif ($additionalCheck
             && ($this->getFileContentWithoutComments($aFile) === $this->getFileContentWithoutComments($bFile))
@@ -149,7 +148,9 @@ class Compare
     public function getFileContentWithoutWhitespace($path)
     {
         $fileStr = file_get_contents($path);
-        $fileStr = str_replace(array(" ","\t","\r","\n"), $fileStr);
+        $lines = explode("\n", $fileStr);
+        $lines = array_map('trim', $lines);
+        $fileStr = implode("\n", $lines);
         return $fileStr;
     }
 

--- a/src/Mpmd/Util/Compare.php
+++ b/src/Mpmd/Util/Compare.php
@@ -17,6 +17,7 @@ class Compare
     const FILE_MISSING_IN_B = 'fileMissingInB';
     const SAME_FILE_BUT_COMMENTS = 'sameFileButComments';
     const FILE_MISSING_IN_A = 'fileMissingInA';
+    const SAME_FILE_BUT_WHITESPACE = 'sameFileButWhitespace';
 
     /**
      * Compare two directories
@@ -80,7 +81,13 @@ class Compare
             return self::IDENTICAL_FILES;
         }
         $extension = strtolower(pathinfo($aFile, PATHINFO_EXTENSION));
-        if (in_array($extension, array('php', 'phtml', 'xml'))
+        
+        $additionalCheck = in_array($extension, array('php', 'phtml', 'xml'));
+        if ($additionalCheck
+            && ($this->getFileContentWithoutWhitespace($aFile) === $this->getFileContentWithoutWhitespace($bFile))
+        ) {
+            return self::SAME_FILE_BUT_WHITESPACE;
+        } elseif ($additionalCheck
             && ($this->getFileContentWithoutComments($aFile) === $this->getFileContentWithoutComments($bFile))
         ) {
             return self::SAME_FILE_BUT_COMMENTS;
@@ -132,6 +139,18 @@ class Compare
         } else {
             throw new \Exception("$extension is not supported here");
         }
+    }
+    
+    /**
+     * Get file content (without whitespace characters)
+     * 
+     * @param $path
+     */
+    public function getFileContentWithoutWhitespace($path)
+    {
+        $fileStr = file_get_contents($path);
+        $fileStr = str_replace(array(" ","\t","\r","\n"), $fileStr);
+        return $fileStr;
     }
 
     /**


### PR DESCRIPTION
This removes spam from whitespace changes between the fresh copy and the existing copy.

Example:

![](http://i.imgur.com/7Sk1Rhg.png)

So much nicer than having 13724 "diferentFileContent" with blank diffs.