### PR TITLE
Separate Patched files into their own group

### DIFF
--- a/src/Mpmd/Magento/CoreHacksCommand.php
+++ b/src/Mpmd/Magento/CoreHacksCommand.php
@@ -89,8 +89,7 @@ class CoreHacksCommand extends \N98\Magento\Command\AbstractMagentoCommand
         $htmlReportOutputPath = $this->_input->getArgument('htmlReportOutputPath');
 
         if ($htmlReportOutputPath) {
-
-            foreach (array(\Mpmd\Util\Compare::DIFFERENT_FILE_CONTENT, \Mpmd\Util\Compare::SAME_FILE_BUT_COMMENTS) as $section) {
+            foreach (array(\Mpmd\Util\Compare::DIFFERENT_FILE_CONTENT, \Mpmd\Util\Compare::SAME_FILE_BUT_COMMENTS, \Mpmd\Util\Compare::FILE_PATCHED_IN_B) as $section) {
                 $diffs[$section] = $compareUtil->getDiffs(
                     $data[$section],
                     $pathToVanillaCore,

--- a/src/Mpmd/Util/Report.php
+++ b/src/Mpmd/Util/Report.php
@@ -63,7 +63,7 @@ class Report extends HtmlRenderer {
             }
         }
 
-        foreach (array(Compare::DIFFERENT_FILE_CONTENT, Compare::SAME_FILE_BUT_COMMENTS) as $section) {
+        foreach (array(Compare::DIFFERENT_FILE_CONTENT, Compare::SAME_FILE_BUT_COMMENTS, Compare::FILE_PATCHED_IN_B) as $section) {
             if (array_key_exists($section, $data)) {
                 if (count($data[$section]) > 0) {
                     $this->addHeadline("Changed files ($section)", 3, array('id' => $idPrefix . $section));
@@ -73,4 +73,4 @@ class Report extends HtmlRenderer {
         }
     }
 
-} 
+}


### PR DESCRIPTION
These PR creates a new section in the corehack report that separates and lists out files that the patch log says have been patched.

An example, a repository compared with a version of Magento patched with the same patches, plus a modification to a file to show that the Diff functionality continues to exist in this section.

![](http://i.imgur.com/qCrC5Br.png)
