### PR TITLE
fix subdirectory scan bug

### DIFF
--- a/src/Mpmd/Util/Compare.php
+++ b/src/Mpmd/Util/Compare.php
@@ -39,7 +39,7 @@ class Compare
             self::SAME_FILE_BUT_WHITESPACE => array(),
         );
         if ($handle = opendir($baseDirA . $path)) {
-            while ($file = readdir($handle)) {
+            while (($file = readdir($handle)) !== false) {
                 if ($file == '.' || $file == '..' || in_array($file, $ignore)) {
                     continue;
                 }


### PR DESCRIPTION
I had the problem, that the corehacks scanner only compared the root directory files and ignored all subdirectorys (eg. app/...).

This small change fix the problem.